### PR TITLE
Resend confirmation link

### DIFF
--- a/src/Infrastructure/Controller/Security/RegisterController.php
+++ b/src/Infrastructure/Controller/Security/RegisterController.php
@@ -41,7 +41,9 @@ final class RegisterController
                 $user = $this->commandBus->handle($registerCommand);
                 $this->commandBus->dispatchAsync(new SendConfirmationLinkCommand($user->getEmail()));
 
-                return new RedirectResponse($this->urlGenerator->generate('app_register_succeeded'));
+                return new RedirectResponse(
+                    $this->urlGenerator->generate('app_register_succeeded', ['email' => $user->getEmail()]),
+                );
             } catch (UserAlreadyRegisteredException) {
                 $form->get('email')->addError(
                     new FormError(

--- a/src/Infrastructure/Controller/Security/RegisterSucceededController.php
+++ b/src/Infrastructure/Controller/Security/RegisterSucceededController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Controller\Security;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
 use Symfony\Component\Routing\Annotation\Route;
 
 final class RegisterSucceededController
@@ -15,10 +16,12 @@ final class RegisterSucceededController
     }
 
     #[Route('/register/succeeded', name: 'app_register_succeeded', methods: ['GET'])]
-    public function __invoke(): Response
+    public function __invoke(#[MapQueryParameter] string $email): Response
     {
         return new Response(
-            $this->twig->render('security/register_succeeded.html.twig'),
+            $this->twig->render('security/register_succeeded.html.twig', [
+                'email' => $email,
+            ]),
         );
     }
 }

--- a/src/Infrastructure/Controller/Security/ResendConfirmationLinkController.php
+++ b/src/Infrastructure/Controller/Security/ResendConfirmationLinkController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Security;
+
+use App\Application\CommandBusInterface;
+use App\Application\User\Command\SendConfirmationLinkCommand;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ResendConfirmationLinkController
+{
+    public function __construct(
+        private readonly CommandBusInterface $commandBus,
+        private readonly UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    #[Route('/register/resend-confirmation-link', name: 'app_resend_confirmation_link', methods: ['POST'])]
+    public function __invoke(#[MapQueryParameter] string $email): Response
+    {
+        $this->commandBus->dispatchAsync(new SendConfirmationLinkCommand($email));
+
+        return new RedirectResponse(
+            $this->urlGenerator->generate('app_register_succeeded', ['email' => $email]),
+        );
+    }
+}

--- a/templates/security/register_succeeded.html.twig
+++ b/templates/security/register_succeeded.html.twig
@@ -7,4 +7,8 @@
 {% block body %}
     <h1>{{ 'register.succeeded.title'|trans }}</h1>
     <p>{{ 'register.succeeded.description'|trans }}</p>
+    <p>{{ 'register.succeeded.email_not_received'|trans }}</p>
+    <form method="POST" action="{{ path('app_resend_confirmation_link', { email }) }}">
+        <button type="submit">{{ 'register.succeeded.send_link'|trans }}</button>
+    </form>
 {% endblock %}

--- a/tests/Integration/Infrastructure/Controller/Security/RegisterSucceededControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Security/RegisterSucceededControllerTest.php
@@ -11,11 +11,19 @@ final class RegisterSucceededControllerTest extends AbstractWebTestCase
     public function testRegisterSucceeded(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/register/succeeded');
+        $crawler = $client->request('GET', '/register/succeeded?email=mathieu@fairness.coop');
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
         $this->assertSame('Vérifiez vos emails', $crawler->filter('h1')->text());
         $this->assertMetaTitle('Vérifiez vos emails - Jeunot', $crawler);
+    }
+
+    public function testMissingEmail(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/register/succeeded');
+
+        $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/tests/Integration/Infrastructure/Controller/Security/ResendConfirmationLinkControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Security/ResendConfirmationLinkControllerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Controller\Security;
+
+use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
+
+final class ResendConfirmationLinkControllerTest extends AbstractWebTestCase
+{
+    public function testResendConfirmationLink(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/register/resend-confirmation-link?email=mathieu@fairness.coop');
+
+        $this->assertResponseStatusCodeSame(302);
+        $client->followRedirect();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertRouteSame('app_register_succeeded');
+    }
+
+    public function testMissingEmail(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/register/resend-confirmation-link');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -94,6 +94,14 @@
                 <source>register.succeeded.description</source>
                 <target>Pour valider la création de votre compte et accéder à votre profil, confirmer votre adresse mail en cliquant sur le lien reçu à votre adresse.</target>
             </trans-unit>
+            <trans-unit id="register.succeeded.email_not_received">
+                <source>register.succeeded.email_not_received</source>
+                <target>Si vous n'avez pas reçu d'email, vous pouvez en renvoyer un en cliquant sur le bouton ci-dessous.</target>
+            </trans-unit>
+            <trans-unit id="register.succeeded.send_link">
+                <source>register.succeeded.send_link</source>
+                <target>Renvoyer un lien</target>
+            </trans-unit>
             <trans-unit id="register.already_registered">
                 <source>register.already_registered</source>
                 <target>Vous avez déjà un compte ?</target>


### PR DESCRIPTION
Cette PR rajoute le mécanisme de renvoi de lien de confirmation de compte.

Maquette cible : 
![image](https://github.com/fairnesscoop/jeunot/assets/2683379/db5cd790-784c-4a6d-8b74-842419644783)

Implémentation :
![image](https://github.com/fairnesscoop/jeunot/assets/2683379/eff2befa-1b19-4b15-ac81-40e5ad84cec5)
![image](https://github.com/fairnesscoop/jeunot/assets/2683379/4d851e51-a7d6-4e9d-8db5-db89c2e39f02)
