### PR TITLE
Update Node.js script due to deprecation warning

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -35,8 +35,12 @@ RUN pecl install apcu && docker-php-ext-enable apcu
 RUN pecl install xdebug && docker-php-ext-enable xdebug
 
 # Install Node.js
-RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash \
-    && apt-get install -y nodejs
+# https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
 
 # Install Symfony cli
 RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | bash && \


### PR DESCRIPTION
En lançant `make install` j'ai reçu un message indiquant que le bash script était déprécié

C'est confirmé par les infos sur cette page : https://github.com/nodesource/distributions

J'ai pris les instructions listées ici : https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions