### PR TITLE
Extract event list template, setting max card width

### DIFF
--- a/assets/styles/layouts/grid.css
+++ b/assets/styles/layouts/grid.css
@@ -2,15 +2,18 @@
   /* Define a flexible grid of elements that share the same size */
   display: grid;
   grid-gap: var(--grid-gap, calc(4 * var(--w)));
+  justify-items: var(--grid-justify-items, normal);
 }
 
 /* Most current browsers should support min() here, but if they don't, the grid will fallback to a single-column layout. */
 @supports (width: min(100px, 100%)) {
   .j-grid {
-    /* auto-fit tells the browser to wrap items into more rows when they can't fit without any overflow. */
-    /* --grid-item-min defines the minimum size an element is allowed to have before wrapping. */
-    /* 1fr ensures elements grow to fill the row, instead of leaving empty space at the end of the row. */
     /*
+    How does this work?
+    * auto-fit tells the browser to wrap items into more rows when they can't fit without any overflow.
+    * --grid-item-min defines the minimum size an element is allowed to have before wrapping.
+    * A max of 1fr ensures elements grow to fill the row, instead of leaving empty space at the end of the row.
+  
     For example, assuming there are 3 items in the grid, no gap (to simplify), and --grid-item-min is 500px...
     Then in a 1200px-wide container, there will be 2 rows: one with 2 items of size 600px, another with 1 item of size 600px and an empty 600px-wide slot.
     In a 800px-wide container, there will be 3 rows of 800px each.

--- a/templates/app/index.html.twig
+++ b/templates/app/index.html.twig
@@ -15,11 +15,7 @@
     </div>
     <div class="j-container j-box" style="--box-padding: calc(6 * var(--w)) 0">
         <h2>{{ 'my_space.upcoming_events'|trans }}</h2>
-        <ul class="j-raw-list j-grid" style="--grid-item-min: 340px" data-testid="event-list">
-            {% for event in paginatedEvents.items %}
-                {% include 'events/_card.html.twig' with { event } only %}
-            {% endfor %}
-        </ul>
+        {% include 'events/_event_grid.html.twig' with { events: paginatedEvents.items } only %}
         <div class="j-center" style="--box-margin: calc(3 * var(--w)) 0 0 0">
             <a href="{{ path('app_events_list') }}" class="j-btn j-btn--lg">
                 {{ 'my_space.upcoming_events.see_more'|trans }}

--- a/templates/events/_card.html.twig
+++ b/templates/events/_card.html.twig
@@ -1,4 +1,4 @@
-<li class="j-card" is="j-card-li">
+<li class="j-card j-max-w" is="j-card-li" style="--max-w: 30rem">
     <figure>
         <div class="j-frame" style="--frame-ratio: 10 / 7">
             <img src="{{ asset('images/placeholder.webp') }}" alt="{{ event.title }}"/>

--- a/templates/events/_event_grid.html.twig
+++ b/templates/events/_event_grid.html.twig
@@ -1,0 +1,5 @@
+<ul class="j-raw-list j-grid" style="--grid-item-min: 340px; --grid-justify-items: center" data-testid="event-list">
+    {% for event in events %}
+        {% include 'events/_card.html.twig' with { event } only %}
+    {% endfor %}
+</ul>

--- a/templates/events/list.html.twig
+++ b/templates/events/list.html.twig
@@ -21,10 +21,6 @@
     <div class="j-container j-box" style="--box-padding: calc(6 * var(--w)) 0">
         <h2>{{ 'events.next_events.title'|trans }}</h2>
 
-        <ul class="j-raw-list j-grid" style="--grid-item-min: 340px" data-testid="event-list">
-            {% for event in paginatedEvents.items %}
-                {% include 'events/_card.html.twig' with { event } only %}
-            {% endfor %}
-        </ul>
+        {% include 'events/_event_grid.html.twig' with { events: paginatedEvents.items } only %}
     </div>
 {% endblock main %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -15,7 +15,7 @@
     {% endblock %}
   </head>
 
-  <body data-controller="grid-observer" data-grid-observer-grid-outlet=".j-grid">
+  <body>
     {% for label, messages in app.flashes %}
         {% if loop.first %}<div class="fr-container">{% endif %}
         {% for message in messages %}


### PR DESCRIPTION
Amélioration de la grille d'événements

* Extraction d'un template réutilisable (la grille était dupliquée à 2 endroits suite à #26)
* Max-width sur les cartes d'événements (essayer sur main avec 1 seul événement, ça prend toute la largeur de la page en desktop et c'est bien moche)
