### PR TITLE
Fix authenticated breadcrumbs

### DIFF
--- a/templates/app/index.html.twig
+++ b/templates/app/index.html.twig
@@ -1,34 +1,34 @@
 {% extends 'layout.html.twig' %}
 
 {% block title %}
-    {{ 'my_space.title'|trans }} - {{ parent() }}
+    {{ 'dashboard.title'|trans }} - {{ parent() }}
 {% endblock %}
 
 {% block main %}
     <div class="j-box j-background-flat-red" style="--box-padding: calc(6 * var(--w))">
         <div class="j-container">
-            <h1>{{ 'my_space.welcome'|trans({'%firstName%': app.user.firstName }) }}</h1>
+            <h1>{{ 'dashboard.welcome'|trans({'%firstName%': app.user.firstName }) }}</h1>
             <div class="j-text-display">
-                <p>{{ 'my_space.description'|trans }}</p>
+                <p>{{ 'dashboard.description'|trans }}</p>
             </div>
         </div>
     </div>
     <div class="j-container j-box" style="--box-padding: calc(6 * var(--w)) 0">
-        <h2>{{ 'my_space.upcoming_events'|trans }}</h2>
+        <h2>{{ 'dashboard.upcoming_events'|trans }}</h2>
         {% include 'events/_event_grid.html.twig' with { events: paginatedEvents.items } only %}
         {% if paginatedEvents.items %}
             <div class="j-box j-center" style="--box-margin: calc(3 * var(--w)) 0 0 0">
                 <a href="{{ path('app_events_list') }}" class="j-btn j-btn--lg">
-                    {{ 'my_space.upcoming_events.see_more'|trans }}
+                    {{ 'dashboard.upcoming_events.see_more'|trans }}
                 </a>
             </div>
         {% endif %}
     </div>
     <div class="j-box j-background-alt-blue" style="--box-padding: calc(6 * var(--w)) 0">
         <div class="j-container">
-            <h2>{{ 'my_space.new_event'|trans }}</h1>
+            <h2>{{ 'dashboard.new_event'|trans }}</h1>
             <div class="j-text-display">
-                <p>{{ 'my_space.new_event.description'|trans|raw }}</p>
+                <p>{{ 'dashboard.new_event.description'|trans|raw }}</p>
             </div>
         </div>
     </div>

--- a/templates/app/profile/detail.html.twig
+++ b/templates/app/profile/detail.html.twig
@@ -9,6 +9,10 @@
 {% block main %}
     {% include 'common/breadcrumb.html.twig' with {
         items: [
+            {
+                title: 'nav.dashboard'|trans,
+                path: path('app_dashboard'),
+            },
             { title: pageTitle }
         ]
     } only %}

--- a/templates/app/profile/edit.html.twig
+++ b/templates/app/profile/edit.html.twig
@@ -10,6 +10,10 @@
     {% include 'common/breadcrumb.html.twig' with {
         items: [
             {
+                title: 'nav.dashboard'|trans,
+                path: path('app_dashboard'),
+            },
+            {
                 title: 'nav.profile'|trans,
                 path: path('app_profile_detail', { uuid: app.user.uuid }),
             },

--- a/templates/app/profile/password.html.twig
+++ b/templates/app/profile/password.html.twig
@@ -10,6 +10,10 @@
     {% include 'common/breadcrumb.html.twig' with {
         items: [
             {
+                title: 'nav.dashboard'|trans,
+                path: path('app_dashboard'),
+            },
+            {
                 title: 'nav.profile'|trans,
                 path: path('app_profile_detail', { uuid: app.user.uuid }),
             },

--- a/templates/common/breadcrumb.html.twig
+++ b/templates/common/breadcrumb.html.twig
@@ -1,9 +1,6 @@
 <div class="j-breadcrumb" style="--box-padding: var(--w)">
     <div class="j-container">
         <ul class="j-raw-list">
-            <li>
-                <a href="{{ path('app_home') }}">Accueil</a>
-            </li>
             {% for item in items %}
                 <li>
                     {% if item.path is defined %}

--- a/templates/common/header_authenticated.html.twig
+++ b/templates/common/header_authenticated.html.twig
@@ -12,7 +12,7 @@
         <ul class="j-raw-list">
             <li>
                 <a href="{{ path('app_dashboard') }}" {% if app.current_route == 'app_dashboard' %}aria-current="page"{% endif %}>
-                    {{ 'nav.my_space'|trans }}
+                    {{ 'nav.dashboard'|trans }}
                 </a>
             </li>
             <li>

--- a/templates/events/detail.html.twig
+++ b/templates/events/detail.html.twig
@@ -9,6 +9,13 @@
 {% block main %}
     {% include 'common/breadcrumb.html.twig' with {
         items: [
+            app.user ? {
+                title: 'nav.dashboard'|trans,
+                path: path('app_dashboard'),
+            } : {
+                title: 'nav.home'|trans,
+                path: path('app_home'),
+            },
             {
                 title: 'nav.events'|trans,
                 path: path('app_events_list'),

--- a/templates/events/list.html.twig
+++ b/templates/events/list.html.twig
@@ -6,7 +6,16 @@
 
 {% block main %}
     {% include 'common/breadcrumb.html.twig' with {
-        items: [ { title: 'nav.events'|trans } ]
+        items: [
+            app.user ? {
+                title: 'nav.dashboard'|trans,
+                path: path('app_dashboard'),
+            } : {
+                title: 'nav.home'|trans,
+                path: path('app_home'),
+            },
+            { title: 'nav.events'|trans },
+        ]
     } only %}
     <div class="j-box j-background-flat-yellow" style="--box-padding: calc(3 * var(--w)) 0">
         <div class="j-container">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -50,8 +50,8 @@
                 <source>nav.register</source>
                 <target>Créer un compte</target>
             </trans-unit>
-            <trans-unit id="nav.my_space">
-                <source>nav.my_space</source>
+            <trans-unit id="nav.dashboard">
+                <source>nav.dashboard</source>
                 <target>Mon espace</target>
             </trans-unit>
             <trans-unit id="nav.logout">
@@ -355,32 +355,32 @@
                 <source>events.registered</source>
                 <target>Inscrit·e !</target>
             </trans-unit>
-            <trans-unit id="my_space.title">
-                <source>my_space.title</source>
+            <trans-unit id="dashboard.title">
+                <source>dashboard.title</source>
                 <target>Mon espace</target>
             </trans-unit>
-            <trans-unit id="my_space.description">
-                <source>my_space.description</source>
+            <trans-unit id="dashboard.description">
+                <source>dashboard.description</source>
                 <target>A quels événements avez-vous envie de participer ?</target>
             </trans-unit>
-            <trans-unit id="my_space.welcome">
-                <source>my_space.welcome</source>
+            <trans-unit id="dashboard.welcome">
+                <source>dashboard.welcome</source>
                 <target>Bonjour %firstName% !</target>
             </trans-unit>
-            <trans-unit id="my_space.new_event">
-                <source>my_space.new_event</source>
+            <trans-unit id="dashboard.new_event">
+                <source>dashboard.new_event</source>
                 <target>Vous avez envie de créer un événement ?</target>
             </trans-unit>
-            <trans-unit id="my_space.new_event.description">
-                <source>my_space.new_event.description</source>
+            <trans-unit id="dashboard.new_event.description">
+                <source>dashboard.new_event.description</source>
                 <target>Vous avez des idées ? Discutons-en ! Ecrivez nous à : <![CDATA[<b>]]>contact@jeunot.fr<![CDATA[</b>]]></target>
             </trans-unit>
-            <trans-unit id="my_space.upcoming_events">
-                <source>my_space.upcoming_events</source>
+            <trans-unit id="dashboard.upcoming_events">
+                <source>dashboard.upcoming_events</source>
                 <target>Vos événements à venir</target>
             </trans-unit>
-            <trans-unit id="my_space.upcoming_events.see_more">
-                <source>my_space.upcoming_events.see_more</source>
+            <trans-unit id="dashboard.upcoming_events.see_more">
+                <source>dashboard.upcoming_events.see_more</source>
                 <target>Voir plus d'événements</target>
             </trans-unit>
             <trans-unit id="profile.edit.title">


### PR DESCRIPTION
Quand on est connecté, la racine du breadcrumb devrait diriger vers "Mon espace" (dashboard), pas vers la page d'accueil non-connecté

J'en profite aussi pour renommer les clés de trad 'my_space' en 'dashboard'