### PR TITLE
Various styling fixes

### DIFF
--- a/assets/styles/components/footer.css
+++ b/assets/styles/components/footer.css
@@ -1,3 +1,30 @@
+footer {
+  flex-grow: 1;
+  background-color: var(--background-flat-black);
+  color: var(--text-on-background-flat-black);
+}
+
+#footer-nav a {
+  display: inline-block;
+  padding-block: var(--w);
+}
+
+@media screen and (min-width: 600px) {
+  #footer-nav ul {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  #footer-nav > ul li:not(:last-child)::after {
+    content: "|";
+    margin-inline: calc(1.5 * var(--v));
+  }
+}
+
+footer hr {
+  border-top: 2px dashed currentColor;
+  width: 100%;
+}
+
 footer .j-h3 {
   color: var(--uri-yellow);
 }

--- a/assets/styles/defaults.css
+++ b/assets/styles/defaults.css
@@ -8,21 +8,6 @@ body {
   height: 100vh;
 }
 
-footer {
-  flex-grow: 1;
-  background-color: var(--background-flat-black);
-  color: var(--text-on-background-flat-black);
-}
-
-footer #footer-nav > ul li:not(:last-child)::after {
-  content: "|";
-  margin-inline: calc(1.5 * var(--v));
-}
-
-footer hr {
-  border-top: 2px dashed currentColor;
-}
-
 h1,
 h2,
 h3,
@@ -40,7 +25,8 @@ h6 {
   margin-bottom: 1em;
 }
 
-h1 {
+h1,
+.j-h1 {
   font-size: var(--font-size-h1);
   line-height: var(--line-height-h1);
 }

--- a/templates/app/index.html.twig
+++ b/templates/app/index.html.twig
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block main %}
-    <div class="j-box j-background-flat-red" style="--box-padding: calc(6 * var(--w))">
+    <div class="j-box j-background-flat-red" style="--box-padding: calc(2 * var(--w)); --box-padding-desktop: calc(6 * var(--w))">
         <div class="j-container">
             <h1>{{ 'dashboard.welcome'|trans({'%firstName%': app.user.firstName }) }}</h1>
             <div class="j-text-display">
@@ -13,11 +13,11 @@
             </div>
         </div>
     </div>
-    <div class="j-container j-box" style="--box-padding: calc(6 * var(--w)) 0">
+    <div class="j-container j-box j-stack" style="--box-padding: calc(6 * var(--w)) 0; --stack-gap: calc(4 * var(--w))">
         <h2>{{ 'dashboard.upcoming_events'|trans }}</h2>
         {% include 'events/_event_grid.html.twig' with { events: paginatedEvents.items } only %}
         {% if paginatedEvents.items %}
-            <div class="j-box j-center" style="--box-margin: calc(3 * var(--w)) 0 0 0">
+            <div class="j-center">
                 <a href="{{ path('app_events_list') }}" class="j-btn j-btn--lg">
                     {{ 'dashboard.upcoming_events.see_more'|trans }}
                 </a>
@@ -26,7 +26,7 @@
     </div>
     <div class="j-box j-background-alt-blue" style="--box-padding: calc(6 * var(--w)) 0">
         <div class="j-container">
-            <h2>{{ 'dashboard.new_event'|trans }}</h1>
+            <h2 class="j-h1">{{ 'dashboard.new_event'|trans }}</h1>
             <div class="j-text-display">
                 <p>{{ 'dashboard.new_event.description'|trans|raw }}</p>
             </div>

--- a/templates/common/footer.html.twig
+++ b/templates/common/footer.html.twig
@@ -69,10 +69,12 @@
         <hr>
 
         <div class="j-cluster j-box" style="--cluster-justify: space-between; --cluster-align: center; --cluster-gap: calc(2 * var(--w)); --box-padding: calc(2 * var(--w)) 0">
-            <small>{{ 'footer.freepik_disclaimer'|trans }}</small>
+            <small lang="en">{{ 'footer.freepik_disclaimer'|trans }}</small>
 
-            <nav id="footer-nav" class="j-text-small j-cluster" style="--cluster-gap: 0" aria-label="Navigation de pied de page">
-                <ul class="j-raw-list j-cluster">
+            <hr class="j-mobile-only">
+
+            <nav id="footer-nav" class="j-text-small" aria-label="Navigation de pied de page">
+                <ul class="j-raw-list">
                     <li>
                         <a href="#">
                             Plan du site

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -373,7 +373,7 @@
             </trans-unit>
             <trans-unit id="dashboard.new_event.description">
                 <source>dashboard.new_event.description</source>
-                <target>Vous avez des idées ? Discutons-en ! Ecrivez nous à : <![CDATA[<b>]]>contact@jeunot.fr<![CDATA[</b>]]></target>
+                <target>Vous avez des idées ? Discutons-en ! Écrivez-nous à : <![CDATA[<a href="mailto:contact@jeunot.fr">]]>contact@jeunot.fr<![CDATA[</a>]]></target>
             </trans-unit>
             <trans-unit id="dashboard.upcoming_events">
                 <source>dashboard.upcoming_events</source>


### PR DESCRIPTION
* Le CSS du footer est entièrement déplacé dans `footer.css`
* Les liens nav du footer s'affichent en liste verticale sur mobile
* Une hr est ajoutée entre le texte "freepik" et les liens nav du footer en mobile
* Le texte "freepik" est marqué comme étant en anglais (critère a11y)
* L'email dans "contactez-nous" sur la page dashboard devient un mailto
* Le padding sur le jumbotron dashboard est réduit sur mobile